### PR TITLE
couple of bug fixes

### DIFF
--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -19,11 +19,6 @@ function _checkCredentials() {
     echo "Error: Neither MM_MFA_TOKEN, MM_TOKEN, nor MM_PASSWORD is set. Please set at least one of them."
     exit 1
   fi
-
-  if [ -z "$MM_MFA_TOKEN" ] && [ -z "$MM_TOKEN" ] && [ -z "$MM_PASSWORD" ]; then
-    echo "Error: Neither MM_MFA_TOKEN, MM_TOKEN, nor MM_PASSWORD is set. Please set at least one of them."
-    exit 1
-  fi
 }
 
 function _usage() {

--- a/resizeEmoji
+++ b/resizeEmoji
@@ -69,7 +69,7 @@ function _moveOversizedImages() {
     if [ -f "$file" ]; then
       width=$(identify -format "%w" "$file")
       height=$(identify -format "%h" "$file")
-      if [ "$width" -gt 1028 ] || [ "$height" -gt 1028 ]; then
+      if [ "$width" -gt 1027 ] || [ "$height" -gt 1027 ]; then
         echo "Moving oversized image $file to failed folder"
         mkdir -p failed
         echo "$file" >> resize_failed.log

--- a/resizeEmoji
+++ b/resizeEmoji
@@ -69,7 +69,7 @@ function _moveOversizedImages() {
     if [ -f "$file" ]; then
       width=$(identify -format "%w" "$file")
       height=$(identify -format "%h" "$file")
-      if [ "$width" -gt 1027 ] || [ "$height" -gt 1027 ]; then
+      if [ "$width" -gt 1024 ] || [ "$height" -gt 1024 ]; then
         echo "Moving oversized image $file to failed folder"
         mkdir -p failed
         echo "$file" >> resize_failed.log

--- a/resizeEmoji
+++ b/resizeEmoji
@@ -18,8 +18,15 @@
 function _resizeEmoji() {
   for file in *.{gif,jpg,jpeg,png}; do
     if [ -f "$file" ]; then
-      echo "Resizing $file ..."
-      convert "$file" -resize 1024x1024 "$file"
+      width=$(identify -format "%w" "${file}[0]")
+      height=$(identify -format "%h" "${file}[0]")
+
+      if [ "$width" -gt 1024 ] || [ "$height" -gt 1024 ]; then
+        echo "Resizing $file ..."
+        convert "$file" -resize 1024x1024 "$file"
+      else
+        echo "$file is not larger than 1024x1024, skipping..."
+      fi
     fi
   done
 }
@@ -67,8 +74,8 @@ function _optimizeGIF() {
 function _moveOversizedImages() {
   for file in *.{gif,jpg,jpeg,png}; do
     if [ -f "$file" ]; then
-      width=$(identify -format "%w" "$file")
-      height=$(identify -format "%h" "$file")
+      width=$(identify -format "%w" "${file}[0]")
+      height=$(identify -format "%h" "${file}[0]")
       if [ "$width" -gt 1024 ] || [ "$height" -gt 1024 ]; then
         echo "Moving oversized image $file to failed folder"
         mkdir -p failed

--- a/resizeEmoji
+++ b/resizeEmoji
@@ -63,7 +63,24 @@ function _optimizeGIF() {
   done
 }
 
+# Function to move oversized images to a failed folder and log the action
+function _moveOversizedImages() {
+  for file in *.{gif,jpg,jpeg,png}; do
+    if [ -f "$file" ]; then
+      width=$(identify -format "%w" "$file")
+      height=$(identify -format "%h" "$file")
+      if [ "$width" -gt 1028 ] || [ "$height" -gt 1028 ]; then
+        echo "Moving oversized image $file to failed folder"
+        mkdir -p failed
+        echo "$file" >> resize_failed.log
+        mv "$file" failed/
+      fi
+    fi
+  done
+}
+
 _resizeEmoji
 _optimizeJPEG
 _optimizePNG
 _optimizeGIF
+_moveOversizedImages


### PR DESCRIPTION
Thanks for the work on this code! I noticed a couple bugs which I fixed.
1. the `_resizeEmoji()` code resizes everything to 1024x1024, even if it's smaller than that, whereas I believe the intention is to only resize the image if it's larger than 1024x1024.
2. `width=$(identify -format "%w" "$file")` and the similar height variable assignment don't work for gifs. chatgpt tells me this has something to do with gifs being composed of many images. So the modified code just takes the first image.